### PR TITLE
Set custom domain lilyzh.ng

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+lilyzh.ng

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,8 @@ minimal_mistakes_skin: dirt
 search: false
 
 # Build settings
+url: "https://lilyzh.ng"
+baseurl: ""
 markdown: kramdown
 remote_theme: mmistakes/minimal-mistakes
 encoding: utf-8


### PR DESCRIPTION
Points the site at the new apex domain **lilyzh.ng**.

- Add CNAME (lilyzh.ng) so GitHub Pages serves the custom domain after deploy.
- Set url: in _config.yml so sitemap / feed / OG tags use the new domain.

Merging triggers the deploy action, which copies CNAME into gh-pages and registers the domain on GitHub Pages.

DNS must be repointed at the registrar before HTTPS works (apex currently parked at 185.53.179.146).