### PR TITLE
Ensure CNAME is emitted to gh-pages on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,5 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: _site
+        cname: lilyzh.ng
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,5 +34,4 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: _site
-        cname: lilyzh.ng
 

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ timezone: America/Los_Angeles # https://en.wikipedia.org/wiki/List_of_tz_databas
 
 include:
   - _pages
+  - CNAME
 
 # Plugins (previously gems:)
 plugins:


### PR DESCRIPTION
Follow-up to #3. The CNAME file was in the source tree but Jekyll did not emit it into _site, so gh-pages had no CNAME and GitHub Pages never registered the custom domain.

Two fixes:
- Add CNAME to Jekyll include: list so it is always copied to _site.
- Set cname: lilyzh.ng on the deploy action (JamesIves drops CNAME on clean deploys otherwise).

Merge this, then the next deploy will put CNAME in gh-pages.